### PR TITLE
Enhance SchemaInfer API and fix labeling

### DIFF
--- a/ai/src/preprocess/labeling.py
+++ b/ai/src/preprocess/labeling.py
@@ -99,7 +99,7 @@ def _process_group(
         j_end = min(len(g), start + horizon_bars)
         h_seg, l_seg = highs[start:j_end], lows[start:j_end]
         evt, t = _first_hit(long_tp, long_sl, short_tp, short_sl, h_seg, l_seg)
-        if evt is None:
+        if evt is None or t is None:
             continue
         global_i = idxs[i]
         signal[global_i] = 1 if evt.startswith("BUY") else 2

--- a/ai/src/preprocess/schema_infer.py
+++ b/ai/src/preprocess/schema_infer.py
@@ -31,12 +31,20 @@ class SchemaInfer:
         max_card (int): Maximum number of unique values to keep per categorical column.
         min_freq (int): Minimum frequency required for a categorical value to be included.
     """
-    def __init__(self, max_card: int = 1000, min_freq: int = 1) -> None:
+    def __init__(
+        self, 
+        max_card: int = 1000, 
+        min_freq: int = 1
+    ) -> None:
         self.max_card = max_card
         self.min_freq = min_freq
         self._schema: Optional[Schema] = None
 
-    def fit(self, df: pd.DataFrame, exclude: Optional[List[str]] = None) -> "SchemaInfer":
+    def fit(
+        self, 
+        df: pd.DataFrame, 
+        exclude: Optional[List[str]] = None
+    ) -> "SchemaInfer":
         """
         Infers schema from the input dataframe.
 
@@ -76,7 +84,10 @@ class SchemaInfer:
         )
         return self
 
-    def transform(self, df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def transform(
+        self, 
+        df: pd.DataFrame
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """
         Transforms input dataframe into numeric and categorical tensors.
 
@@ -98,7 +109,10 @@ class SchemaInfer:
             cat[col] = df[col].map(vocab).fillna(unk).astype("Int64") # type: ignore
         return num, cat
 
-    def inverse_transform(self, cat_df: pd.DataFrame) -> pd.DataFrame:
+    def inverse_transform(
+        self, 
+        cat_df: pd.DataFrame
+    ) -> pd.DataFrame:
         """
         Converts encoded categorical indices back to original string values.
 
@@ -117,7 +131,11 @@ class SchemaInfer:
             inv[col] = cat_df[col].map(reverse_vocab).fillna(f"[UNK_{col}]") # type: ignore
         return inv
 
-    def fit_transform(self, df: pd.DataFrame, exclude: Optional[List[str]] = None) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def fit_transform(
+        self, 
+        df: pd.DataFrame, 
+        exclude: Optional[List[str]] = None
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """
         Fits schema and transforms the input dataframe in one step.
 
@@ -163,3 +181,19 @@ class SchemaInfer:
         if self._schema is None:
             return "SchemaInfer(fit=False)"
         return f"SchemaInfer(fit=True, num={len(self._schema.num_cols)}, cat={len(self._schema.cat_cols)})"
+
+    @property
+    def num_cols(self) -> List[str]:
+        return self.get_schema().num_cols
+
+    @property
+    def cat_cols(self) -> List[str]:
+        return self.get_schema().cat_cols
+
+    @property
+    def cat_vocabs(self) -> Dict[str, Dict[str, int]]:
+        return self.get_schema().cat_vocabs
+
+    @property
+    def cat_unk_idx(self) -> Dict[str, int]:
+        return self.get_schema().cat_unk_idx

--- a/strategies/src/infrastructure/indicators/scrsi.py
+++ b/strategies/src/infrastructure/indicators/scrsi.py
@@ -47,7 +47,8 @@ class SmoothCicleRsi:
         Returns:
             pd.DataFrame: A DataFrame containing the SCRSI 
             scaled values and boundary levels.
-        """        # Compute cycle length and cyclic memory for smoothing
+        """        
+        # Compute cycle length and cyclic memory for smoothing
         cyclelen = config.domcycle // 2
         cyclicmemory = config.domcycle * 2
         # Calculate price differences


### PR DESCRIPTION
## Сводка от Sourcery

Улучшить API вывода схемы с помощью новых свойств и более чистого форматирования, исправить крайний случай разметки и привести в порядок docstrings индикаторов.

Исправления ошибок:
- Пропускать присвоение метки, когда временной индекс t равен None в рабочем процессе разметки

Улучшения:
- Добавить свойства только для чтения в SchemaInfer для доступа к деталям числовой и категориальной схемы
- Рефакторинг сигнатур методов в SchemaInfer для использования многострочного форматирования для улучшения читаемости

Рутинные задачи:
- Скорректировать форматирование docstring/комментариев при расчете индикатора SCRSI

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve schema inference API with new properties and cleaner formatting, fix labeling edge case, and tidy up indicator docstrings.

Bug Fixes:
- Skip label assignment when time index t is None in labeling workflow

Enhancements:
- Add read-only properties to SchemaInfer for accessing numerical and categorical schema details
- Refactor method signatures in SchemaInfer to use multi-line formatting for readability

Chores:
- Adjust docstring/comment formatting in SCRSI indicator calculation

</details>